### PR TITLE
Revert "fix: for windows users (#26)"

### DIFF
--- a/src/packBaseLayer.ts
+++ b/src/packBaseLayer.ts
@@ -63,7 +63,6 @@ export const packBaseLayer = async (args: {
     console.error(chalk.gray(`npm ci --ignore-scripts --only=prod`));
     const p = spawn('npm', ['ci', '--ignore-scripts', '--only=prod'], {
       cwd: installDir,
-      shell: true,
     });
     p.on('close', code => {
       if (code !== 0) {


### PR DESCRIPTION
This reverts commit 9b3222f622ecfd9787df55f60bb2c522fb8816b1.

Originally intended so that development can support windows users. It MAY of had an unintended side effect. CI builds for iris-backend show authentication failures after this change.